### PR TITLE
extend idea versions range

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,14 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 intellij {
-    version '2016.3'
+    version '171.3780.15'
     pluginName 'deps-checker'
     sandboxDirectory = "${rootProject.rootDir}/idea-sandbox"
     publish {
         username project.hasProperty('publishUsername') ? project.property('publishUsername') : ''
         password project.hasProperty('publishPassword') ? project.property('publishPassword') : ''
     }
+    updateSinceUntilBuild = false
 }
 
 group 'com.touwolf.plugin.idea.depschecker'

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin version="3">
+<idea-plugin>
     <id>touwolf.depschecker</id>
     <name>Java Dependencies Checker</name>
     <vendor email="miche.atucha@gmail.com"
@@ -22,7 +22,7 @@
 
     <depends>com.intellij.modules.java</depends>
 
-    <idea-version since-build="2016.3" />
+    <idea-version since-build="162.1121"/>
 
     <extensions defaultExtensionNs="com.intellij" />
 


### PR DESCRIPTION
After this fix plugin becomes compatible not only with 2016.3 Idea but also with 2016.2 and 2017.1 EAP. Tested with all of listed versions.